### PR TITLE
Shift head.css ahead of head.js in DOM

### DIFF
--- a/AssetsMinifyInit.php
+++ b/AssetsMinifyInit.php
@@ -148,9 +148,6 @@ class AssetsMinifyInit {
 
 	public function headerServe() {
 
-		//Manage the scripts to be printed in the header
-		$this->headerServeScripts();
-
 		//Compile css stylesheets
 		$this->generateCss();
 
@@ -176,6 +173,9 @@ class AssetsMinifyInit {
 
 		//Print css inclusion in the page
 		$this->dumpCss( 'head.css' );
+
+		//Manage the scripts to be printed in the header
+		$this->headerServeScripts();
 
 	}
 


### PR DESCRIPTION
Shifted head.js below head.css as JS blocks parallel downloads.

http://developer.yahoo.com/performance/rules.html#js_bottom
