### PR TITLE
Adding "exclude" filter for themes; updating caching 

### DIFF
--- a/AssetsMinifyInit.php
+++ b/AssetsMinifyInit.php
@@ -129,6 +129,8 @@ class AssetsMinifyInit {
 			//Doesn't manage other domains included scripts
 			if ( strpos($script, "http") === 0 || strpos($script, "//") === 0 )
 				continue;
+			if ((($theme = wp_get_theme()) && $theme_hook = $theme->template.'_asset_minify_exclude') && function_exists($theme_hook) && $theme_hook($handle, $script))
+				continue; 
 
 			$where = 'footer';
 			//Unfortunately not every WP plugin developer is a JS ninja
@@ -174,6 +176,8 @@ class AssetsMinifyInit {
 			//Doesn't manage other domains included stylesheets
 			if ( strpos($style, "http") === 0 || strpos($style, "//") === 0 )
 				continue;
+			if ((($theme = wp_get_theme()) && $theme_hook = $theme->template.'_asset_minify_exclude') && function_exists($theme_hook) && $theme_hook($handle, $style))
+				continue; 
 
 			//Separation between css-frameworks stylesheets and .css stylesheets
 			$ext = substr( $style, -5 );
@@ -251,7 +255,7 @@ class AssetsMinifyInit {
 		if ( empty($this->sass) )
 			return false;
 
-		$mtime = md5(implode('&', $this->mTimesSass));
+		$mtime = md5(implode('&', $this->mTimesSass) . implode('&', $this->sass));
 
 		//If SASS stylesheets have been updated -> compass compile
 		if ( !$this->cache->has( "sass-{$mtime}.css" ) ) {
@@ -286,7 +290,7 @@ class AssetsMinifyInit {
 		if ( empty($this->less) )
 			return false;
 
-		$mtime = md5(implode('&', $this->mTimesLess));
+		$mtime = md5(implode('&', $this->mTimesLess) . implode('&', $this->less));
 
 		//If LESS stylesheets have been updated compile them
 		if ( !$this->cache->has( "less-{$mtime}.css" )  ) {
@@ -310,7 +314,7 @@ class AssetsMinifyInit {
 		if ( empty($this->styles) )
 			return false;
 
-		$mtime = md5(implode('&', $this->mTimesStyles));
+		$mtime = md5(implode('&', $this->mTimesStyles) . implode('&', $this->styles));
 
 		//If CSS stylesheets have been updated compile and save them 
 		if ( !$this->cache->has( "styles-{$mtime}.css" ) )
@@ -329,7 +333,7 @@ class AssetsMinifyInit {
 		if ( empty($this->scripts['header']) )
 			return false;
 
-		$mtime = md5(implode('&', $this->mTimes['header']));
+		$mtime = md5(implode('&', $this->mTimes['header']) . implode('&', $this->scripts['header']) );
 
 		//Saves the asseticized header scripts
 		if ( !$this->cache->has( "head-{$mtime}.js" ) )
@@ -347,7 +351,7 @@ class AssetsMinifyInit {
 		if ( empty($this->scripts['footer']) )
 			return false;
 
-		$mtime = md5(implode('&', $this->mTimes['footer']));
+		$mtime = md5(implode('&', $this->mTimes['footer']) . implode('&', $this->scripts['footer']));
 
 		//Saves the asseticized footer scripts
 		if ( !$this->cache->has( "foot-{$mtime}.js" ) )


### PR DESCRIPTION
Fantastic plugin and really appreciate the code is so clean. These updates address to issues.  (1) the leading "http" or "//" was not enough for me excluding some scripts from minification.  (2) With a matching number of scripts (say 4) mis-matching cache files can get returned.  

If accepted the change allows themers to use something like below in mytheme/functions.php file to exclude scripts: 
function MYTHEME_asset_minify_exclude($queueHandle = '', $queueSource = 'http://') {
    $skipFile = false; 
    $skipFile = defined('WP_DEBUG') && WP_DEBUG === true ? true : $skipFile;
    $skipFile = strpos($queueSource, '.min') ? true : $skipFile;
    return $skipFile; 
}

We needed to exclude minify scripts on http://corbiscrave.com.  The second change was needed because our deployments left all scripts with the same maketime. If /search/ had 4 scrips and /recipes/ had 4 scripts, the original cache file was getting used. 

Again, thanks for the fantastic and clear classes.  
