### PR TITLE
Make minification optional

### DIFF
--- a/AssetsMinifyAdmin.php
+++ b/AssetsMinifyAdmin.php
@@ -37,7 +37,9 @@ class AssetsMinifyAdmin {
 		register_setting('am_options_group', 'am_compass_path');
 		register_setting('am_options_group', 'am_coffeescript_path');
 		register_setting('am_options_group', 'am_compress_styles');
+		register_setting('am_options_group', 'am_minify_styles');
 		register_setting('am_options_group', 'am_compress_scripts');
+		register_setting('am_options_group', 'am_minify_scripts');
 		register_setting('am_options_group', 'am_files_to_exclude');
 	}
 

--- a/AssetsMinifyInit.php
+++ b/AssetsMinifyInit.php
@@ -66,13 +66,17 @@ class AssetsMinifyInit {
 		$this->css->setFilterManager( new FilterManager );
 
 		//Defines filter for js minify
-		$this->js->getFilterManager()->set($this->jsMin, new JSMinFilter);
-		$this->jsFilters []= $this->jsMin;
+		if (get_option('am_minify_scripts')) {
+			$this->js->getFilterManager()->set($this->jsMin, new JSMinFilter);
+			$this->jsFilters []= $this->jsMin;
+		}
 
 		//Defines filter for css minify
-		$this->css->getFilterManager()->set($this->cssMin, new CssMinFilter);
 		$this->css->getFilterManager()->set('CssRewrite', new CssRewriteFilter);
-		$this->cssFilters []= $this->cssMin;
+		if (get_option('am_minify_styles')) {
+			$this->css->getFilterManager()->set($this->cssMin, new CssMinFilter);
+			$this->cssFilters []= $this->cssMin;
+		}
 
 		//Define assets path to save asseticized files
 		$uploadsDir = wp_upload_dir();

--- a/templates/settings.phtml
+++ b/templates/settings.phtml
@@ -49,6 +49,22 @@
                 </tr>
                 <tr valign="top">
                     <th scope="row">
+                        <label for="am_minify_styles">Minify styles</label>
+                    </th>
+                    <td>
+                        <input name="am_minify_styles" type="checkbox" id="am_minify_styles" value="1" <?php checked(1, get_option('am_minify_styles', 1)); ?>>
+                    </td>
+                </tr>
+                <tr valign="top">
+                    <th scope="row">
+                        <label for="am_minify_scripts">Minify scripts</label>
+                    </th>
+                    <td>
+                        <input name="am_minify_scripts" type="checkbox" id="am_minify_scripts" value="1" <?php checked(1, get_option('am_minify_scripts', 1)); ?>>
+                    </td>
+                </tr>
+                <tr valign="top">
+                    <th scope="row">
                         <label for="am_files_to_exclude">Resources to exclude</label>
                     </th>
                     <td>


### PR DESCRIPTION
For some reason, my stylesheets were broken after minifaction.
Therefore, this pull request adds settings to the admin interface to make minification optional. Not sure if the naming is clear enough ("compress" vs. "minify"). Maybe rename "compress" to "process"?
