### PR TITLE
Fix for protocol-relative URLs accessed over HTTPs

### DIFF
--- a/src/AssetsMinify/Assets/Factory.php
+++ b/src/AssetsMinify/Assets/Factory.php
@@ -118,7 +118,7 @@ abstract class Factory {
 	 * @return string The regular expression matching the URL.
 	 */
 	protected function getUrlRegex( $url ) {
-		$regex  = '@^' . str_replace( 'http\://','(https?\:)?\/\/', preg_quote( $url )) . '@';
+		$regex  = '@^' . str_replace( array( 'https\://', 'http\://' ), '(https?\:)?\/\/', preg_quote( $url )) . '@';
 		return $regex;
 	}
 }


### PR DESCRIPTION
I noticed that the plugin wouldn't pick up assets referenced by protocol-relative URLs (those omitting the http:/https: part) -- only when the website was served over HTTPS. This change fixes it.
