### PR TITLE
Use md5 for mtime rather than filemtime

### DIFF
--- a/src/AssetsMinify/Assets/Css.php
+++ b/src/AssetsMinify/Assets/Css.php
@@ -97,7 +97,7 @@ class Css extends Factory {
 
 				$key = "$media-$ext-am-generated";
 				$this->files[$media][$key] = $this->cache->getPath() . $cachefile;
-				$this->mtimes[$media][$key] = filemtime($this->files[$media][$key]);
+				$this->mtimes[$media][$key] = $mtime;
 			}
 		}
 
@@ -105,7 +105,7 @@ class Css extends Factory {
 			return false;
 
 		foreach ( $this->files as $media => $files) {
-			$mtime = md5( json_encode($this->mtimes[$media]) );
+			$mtime = $this->mtimes[$media]["$media-css-am-generated"];
 
 			//Saves the asseticized stylesheets
 			$cachedFilename = "head-$media-$mtime.css";

--- a/src/AssetsMinify/Assets/Js.php
+++ b/src/AssetsMinify/Assets/Js.php
@@ -103,13 +103,13 @@ class Js extends Factory {
 
 			$key = "$ext-am-generated";
 			$this->files[$where][$key] = $this->cache->getPath() . $cachefile;
-			$this->mtimes[$where][$key] = filemtime($this->files[$where][$key]);
+			$this->mtimes[$where][$key] = $mtime;
 		}
 
 		if ( empty($this->files[$where]) )
 			return false;
 
-		$mtime = md5( json_encode($this->mtimes[$where]) );
+		$mtime = $this->mtimes[$where]["js-am-generated"];
 
 		//Saves the asseticized header scripts
 		if ( !$this->cache->fs->has( "$where-$mtime.js" ) ) {


### PR DESCRIPTION
Using the file mtime of a generated asset means that the resulting file name will be different every time this function is run.  This causes problems if load balancing across multiple servers as the mtime will be slightly different on each server.  This will mean each server generates an asset file with a different name.  Re-using the md5 from the pre-minified asset should be safe.
